### PR TITLE
fix patette name of settings.js

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -268,7 +268,7 @@ module.exports = {
     // added to the end of the palette.
     // If not set, the following default order is used:
 	paletteCategories: ['subflows', 'common', 'iaCloud services', 'iaCloud devices', 'iaCloud functions'
-				, 'iaCloud', 'iaCloud DB access', 'iaCloud visuals','iaCloud dashboard', 'dashboard'
+				, 'iaCloud', 'iaCloud DB acs', 'iaCloud Visuals','iaCloud dashboard', 'dashboard'
 				, 'function', 'network', 'sequence', 'parser', 'storage'],
 
     // Configure the logging output


### PR DESCRIPTION
settings.js内のパレット名と、実際のノードのパレット名に齟齬がありましたので修正です。
ご確認の程、よろしくお願い致します。